### PR TITLE
INF-2062 feat: Add stable-only publishing workflow

### DIFF
--- a/.github/workflows/publish-stable-only.yml
+++ b/.github/workflows/publish-stable-only.yml
@@ -1,0 +1,456 @@
+name: Publish Stable Package
+
+on:
+  push:
+    tags:
+      # Only match stable version tags (no beta, alpha, rc, or pre-release)
+      - "v[0-9]+.[0-9]+.[0-9]+"  # Matches v1.0.0, v2.1.3, etc.
+      # Exclude any tags with pre-release identifiers
+      - "!v*-*"  # Excludes v1.0.0-beta, v1.0.0-alpha, etc.
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to publish (leave empty for all)'
+        required: false
+        type: string
+        default: ''
+      skip_version_check:
+        description: 'Skip pre-release version check (use with caution)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  validate-version:
+    # prevents this action from running on forks
+    if: github.repository == 'mi-examples/pp-dev-js'
+    runs-on: ubuntu-latest
+    outputs:
+      is_stable: ${{ steps.check-version.outputs.is_stable }}
+      version: ${{ steps.check-version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if version is stable
+        id: check-version
+        run: |
+          # Extract version from tag
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            TAG_NAME="${GITHUB_REF_NAME}"
+            echo "Checking tag: $TAG_NAME"
+            
+            # Remove 'v' prefix if present
+            VERSION="${TAG_NAME#v}"
+            
+            # Check if this is a stable version (no pre-release identifiers)
+            if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "✅ Stable version detected: $VERSION"
+              echo "is_stable=true" >> $GITHUB_OUTPUT
+              echo "version=$VERSION" >> $GITHUB_OUTPUT
+            elif [[ "$VERSION" =~ (beta|alpha|rc|pre|preview|dev|canary) ]]; then
+              echo "❌ Pre-release version detected: $VERSION"
+              echo "This workflow only publishes stable versions."
+              echo "Use the beta-release workflow for pre-release versions."
+              echo "is_stable=false" >> $GITHUB_OUTPUT
+              echo "version=$VERSION" >> $GITHUB_OUTPUT
+              exit 1
+            else
+              echo "⚠️ Version format not recognized: $VERSION"
+              echo "Expected format: X.Y.Z (e.g., 1.0.0)"
+              echo "is_stable=false" >> $GITHUB_OUTPUT
+              echo "version=$VERSION" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # For manual trigger, check if skip_version_check is enabled
+            if [[ "${{ github.event.inputs.skip_version_check }}" == "true" ]]; then
+              echo "⚠️ Version check skipped (manual override)"
+              echo "is_stable=true" >> $GITHUB_OUTPUT
+              echo "version=manual" >> $GITHUB_OUTPUT
+            else
+              echo "is_stable=true" >> $GITHUB_OUTPUT
+              echo "version=manual" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+  detect-packages:
+    needs: validate-version
+    if: needs.validate-version.outputs.is_stable == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.set-packages.outputs.packages }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get packages to publish
+        id: set-packages
+        run: |
+          packages="[]" # Default to empty array
+          
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.package }}" ]]; then
+            # For manual trigger with specified package
+            if [[ -d "packages/${{ github.event.inputs.package }}" ]]; then
+              packages="[\"${{ github.event.inputs.package }}\"]"
+            else
+              echo "Error: Package '${{ github.event.inputs.package }}' not found in packages directory"
+              exit 1
+            fi
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # For manual trigger without specified package, use all packages
+            if [[ -d "packages" ]]; then
+              all_packages=($(ls -d packages/*/ 2>/dev/null | cut -d'/' -f2 | grep -v '^$'))
+              if [[ ${#all_packages[@]} -gt 0 ]]; then
+                packages=$(printf '"%s",' "${all_packages[@]}" | sed 's/,$//' | sed 's/^/\[/; s/$/\]/')
+              fi
+            fi
+          else
+            # For tags, determine package name based on tag format
+            if [[ $GITHUB_REF_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              # This is a stable version tag
+              packages='["pp-dev"]' # JSON array for stable v* tags
+            else
+              # Extract package name from tags like package-name@version
+              pkg_name=${GITHUB_REF_NAME%@*}
+              # If pkg_name is not empty and package exists, format as JSON array
+              if [[ -n "$pkg_name" && -d "packages/$pkg_name" ]]; then
+                  packages="[\"$pkg_name\"]" # JSON array for specific package tag
+              fi
+            fi
+          fi
+          
+          echo "packages=$packages" >> $GITHUB_OUTPUT
+          echo "Generated packages output: $packages"
+          echo "Debug - packages output format: '$packages'"
+          echo "Debug - JSON validation: $(echo "$packages" | jq . 2>/dev/null || echo "INVALID JSON")"
+          
+          # Validate JSON output
+          if ! echo "$packages" | jq . >/dev/null 2>&1; then
+            echo "Error: Invalid JSON generated for packages"
+            exit 1
+          fi
+          
+          # Always exit successfully - packages array is valid
+          echo "✅ Package detection completed successfully"
+
+  # Publish pp-dev first (core package)
+  publish-pp-dev:
+    needs: [validate-version, detect-packages]
+    if: ${{ contains(fromJSON(needs.detect-packages.outputs.packages), 'pp-dev') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    environment: Release
+    defaults:
+      run:
+        working-directory: packages/pp-dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+          cache: 'npm'
+
+      - name: Validate package version is stable
+        run: |
+          # Get version from package.json
+          pkg_version=$(node -p "require('./package.json').version")
+          echo "Package version: $pkg_version"
+          
+          # Check if version contains pre-release identifiers
+          if [[ "$pkg_version" =~ (beta|alpha|rc|pre|preview|dev|canary) ]]; then
+            echo "❌ Error: Package version contains pre-release identifier: $pkg_version"
+            echo "Please update package.json to contain a stable version (X.Y.Z format)"
+            exit 1
+          fi
+          
+          # Verify it's a proper semantic version
+          if [[ ! "$pkg_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Error: Package version is not in stable semantic version format: $pkg_version"
+            echo "Expected format: X.Y.Z (e.g., 1.0.0)"
+            exit 1
+          fi
+          
+          echo "✅ Package version is stable: $pkg_version"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Verify build output
+        run: |
+          # Check if dist directory exists and has content
+          if [[ ! -d "dist" ]]; then
+            echo "Error: Build output directory 'dist' not found"
+            exit 1
+          fi
+          
+          # Check if package.json exists in dist (for most packages)
+          if [[ -f "package.json" ]] && [[ ! -f "dist/package.json" ]]; then
+            echo "Warning: No package.json found in dist directory"
+          fi
+          
+          echo "Build verification passed"
+
+      - name: Publish Package (Stable Only)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+          NPM_TOKEN: ${{ secrets.npm_token }}
+        run: |
+          echo "Publishing stable package from tag: $GITHUB_REF_NAME"
+          
+          # Double-check we're not publishing a beta version
+          pkg_version=$(node -p "require('./package.json').version")
+          if [[ "$pkg_version" =~ (beta|alpha|rc|pre) ]]; then
+            echo "❌ Aborting: Attempting to publish pre-release version: $pkg_version"
+            exit 1
+          fi
+          
+          # Publish with 'latest' tag (default for stable versions)
+          npm publish --access public --tag latest
+
+      - name: Verify publication
+        run: |
+          # Get package name from package.json
+          pkg_name=$(node -p "require('./package.json').name")
+          pkg_version=$(node -p "require('./package.json').version")
+          
+          echo "Verifying publication of $pkg_name@$pkg_version"
+          
+          # Wait a moment for npm registry to update
+          sleep 10
+          
+          # Check if package is available on npm
+          if npm view "$pkg_name@$pkg_version" version >/dev/null 2>&1; then
+            echo "✅ Successfully published stable version $pkg_name@$pkg_version"
+          else
+            echo "❌ Failed to verify publication of $pkg_name@$pkg_version"
+            exit 1
+          fi
+
+  # Publish create-pp-dev second (depends on pp-dev)
+  publish-create-pp-dev:
+    needs: [validate-version, detect-packages, publish-pp-dev]
+    if: ${{ contains(fromJSON(needs.detect-packages.outputs.packages), 'create-pp-dev') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    environment: Release
+    defaults:
+      run:
+        working-directory: packages/create-pp-dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+          cache: 'npm'
+
+      - name: Validate package version is stable
+        run: |
+          # Get version from package.json
+          pkg_version=$(node -p "require('./package.json').version")
+          echo "Package version: $pkg_version"
+          
+          # Check if version contains pre-release identifiers
+          if [[ "$pkg_version" =~ (beta|alpha|rc|pre|preview|dev|canary) ]]; then
+            echo "❌ Error: Package version contains pre-release identifier: $pkg_version"
+            echo "Please update package.json to contain a stable version (X.Y.Z format)"
+            exit 1
+          fi
+          
+          # Verify it's a proper semantic version
+          if [[ ! "$pkg_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Error: Package version is not in stable semantic version format: $pkg_version"
+            echo "Expected format: X.Y.Z (e.g., 1.0.0)"
+            exit 1
+          fi
+          
+          echo "✅ Package version is stable: $pkg_version"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Verify build output
+        run: |
+          # Check if dist directory exists and has content
+          if [[ ! -d "dist" ]]; then
+            echo "Error: Build output directory 'dist' not found"
+            exit 1
+          fi
+          
+          # Check if package.json exists in dist (for most packages)
+          if [[ -f "package.json" ]] && [[ ! -f "dist/package.json" ]]; then
+            echo "Warning: No package.json found in dist directory"
+          fi
+          
+          echo "Build verification passed"
+
+      - name: Verify pp-dev dependency
+        run: |
+          echo "Verifying pp-dev release exists..."
+          git fetch --tags origin
+          
+          if ! git tag --list | grep -q "^v[0-9]"; then
+            echo "Error: pp-dev tag not found. Cannot proceed with create-pp-dev publish."
+            exit 1
+          fi
+          echo "pp-dev dependency verified successfully"
+
+      - name: Update pp-dev dependency to latest stable version
+        run: |
+          echo "Updating pp-dev dependency to latest stable version..."
+          
+          # Get the latest stable pp-dev version from git tags (excluding beta versions)
+          latest_pp_dev_version=$(git tag --list "v*" | grep -v "beta\|alpha\|rc\|pre" | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -n1 | sed 's/^v//')
+          echo "Latest stable pp-dev version: $latest_pp_dev_version"
+          
+          if [[ -z "$latest_pp_dev_version" ]]; then
+            echo "Error: Could not determine latest stable pp-dev version"
+            exit 1
+          fi
+          
+          # Update package.json dependency
+          npm pkg set "dependencies.@metricinsights/pp-dev" "^$latest_pp_dev_version"
+          
+          # Update template package.json files
+          find . -name "package.json" -path "*/template-*/*" -exec sed -i "s/\"@metricinsights\/pp-dev\": \"[^\"]*\"/\"@metricinsights\/pp-dev\": \"^$latest_pp_dev_version\"/g" {} \;
+          
+          # Update any other version references in template files
+          find . -path "*/template-*/*" -type f -name "*.json" -exec sed -i "s/\"@metricinsights\/pp-dev\": \"[^\"]*\"/\"@metricinsights\/pp-dev\": \"^$latest_pp_dev_version\"/g" {} \;
+          
+          echo "Updated pp-dev dependency to stable version ^$latest_pp_dev_version"
+          
+          # Show the changes
+          echo "Updated package.json:"
+          grep "@metricinsights/pp-dev" package.json
+          
+          echo "Updated template files:"
+          find . -path "*/template-*/*" -name "package.json" -exec grep -l "@metricinsights/pp-dev" {} \;
+
+      - name: Commit dependency updates
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Committing dependency updates..."
+            git add .
+            git commit -m "chore(deps): update pp-dev dependency to latest stable version"
+            git push origin HEAD:main
+          else
+            echo "No dependency updates to commit"
+          fi
+
+      - name: Publish Package (Stable Only)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+          NPM_TOKEN: ${{ secrets.npm_token }}
+        run: |
+          echo "Publishing stable package from tag: $GITHUB_REF_NAME"
+          
+          # Double-check we're not publishing a beta version
+          pkg_version=$(node -p "require('./package.json').version")
+          if [[ "$pkg_version" =~ (beta|alpha|rc|pre) ]]; then
+            echo "❌ Aborting: Attempting to publish pre-release version: $pkg_version"
+            exit 1
+          fi
+          
+          # Publish with 'latest' tag (default for stable versions)
+          npm publish --access public --tag latest
+
+      - name: Verify publication
+        run: |
+          # Get package name from package.json
+          pkg_name=$(node -p "require('./package.json').name")
+          pkg_version=$(node -p "require('./package.json').version")
+          
+          echo "Verifying publication of $pkg_name@$pkg_version"
+          
+          # Wait a moment for npm registry to update
+          sleep 10
+          
+          # Check if package is available on npm
+          if npm view "$pkg_name@$pkg_version" version >/dev/null 2>&1; then
+            echo "✅ Successfully published stable version $pkg_name@$pkg_version"
+          else
+            echo "❌ Failed to verify publication of $pkg_name@$pkg_version"
+            exit 1
+          fi
+
+  create-release:
+    needs: [validate-version, detect-packages, publish-pp-dev]
+    if: needs.validate-version.outputs.is_stable == 'true' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ needs.validate-version.outputs.version }}';
+            const tagName = context.ref.replace('refs/tags/', '');
+            
+            // Generate release notes (you can customize this)
+            const releaseNotes = `## 🎉 Stable Release ${version}
+            
+            This is a stable release of the pp-dev-js packages.
+            
+            ### 📦 Published Packages
+            - @metricinsights/pp-dev@${version}
+            - @metricinsights/create-pp-dev (if applicable)
+            
+            ### 📋 Installation
+            \`\`\`bash
+            npm install @metricinsights/pp-dev@${version}
+            # or
+            npm install @metricinsights/pp-dev@latest
+            \`\`\`
+            
+            ### 🔗 Links
+            - [npm package](https://www.npmjs.com/package/@metricinsights/pp-dev)
+            - [Documentation](https://github.com/mi-examples/pp-dev-js#readme)
+            `;
+            
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tagName,
+              name: `Release ${version}`,
+              body: releaseNotes,
+              draft: false,
+              prerelease: false
+            });
+            
+            console.log(`Created release ${release.data.html_url}`);

--- a/STABLE_RELEASE_GUIDE.md
+++ b/STABLE_RELEASE_GUIDE.md
@@ -1,0 +1,133 @@
+# Stable Release Publishing Guide
+
+## Overview
+
+This repository now has two separate GitHub Actions workflows for publishing packages to npm:
+
+1. **`beta-release.yml`** - Automatically publishes beta/pre-release versions when pushing to the `develop` branch
+2. **`publish-stable-only.yml`** - Only publishes stable versions when creating release tags
+
+## Key Changes in the Stable-Only Workflow
+
+### 1. Tag Pattern Matching
+The workflow only triggers on stable version tags:
+```yaml
+tags:
+  - "v[0-9]+.[0-9]+.[0-9]+"  # Matches v1.0.0, v2.1.3, etc.
+  - "!v*-*"                   # Excludes v1.0.0-beta, v1.0.0-alpha, etc.
+```
+
+### 2. Version Validation
+Multiple validation checks ensure only stable versions are published:
+
+- **Tag validation**: Checks if the tag follows stable semantic versioning (X.Y.Z)
+- **Package.json validation**: Verifies the version in package.json doesn't contain pre-release identifiers
+- **Pre-publish validation**: Double-checks before npm publish command
+
+### 3. Prevented Pre-release Identifiers
+The workflow will reject versions containing:
+- `beta`
+- `alpha`
+- `rc` (release candidate)
+- `pre`
+- `preview`
+- `dev`
+- `canary`
+
+## How to Use
+
+### Publishing a Stable Release
+
+1. **Update the version in package.json** (must be in X.Y.Z format):
+   ```bash
+   cd packages/pp-dev
+   # Update version to stable format (e.g., 0.11.0, not 0.11.0-beta.4)
+   npm version 0.11.0 --no-git-tag-version
+   ```
+
+2. **Commit the version change**:
+   ```bash
+   git add .
+   git commit -m "chore: release version 0.11.0"
+   git push origin main
+   ```
+
+3. **Create and push a stable version tag**:
+   ```bash
+   git tag v0.11.0
+   git push origin v0.11.0
+   ```
+
+4. **The workflow will automatically**:
+   - Validate that the tag is a stable version
+   - Check that package.json contains a stable version
+   - Build the package
+   - Publish to npm with the `latest` tag
+   - Create a GitHub release
+
+### Publishing Beta/Pre-release Versions
+
+Beta versions are handled separately:
+
+1. Work on the `develop` branch
+2. Versions with `-beta.X` suffix will be published automatically when pushing to `develop`
+3. These will be published to npm with the `beta` tag, not `latest`
+
+### Manual Trigger (Emergency Use)
+
+The workflow can be triggered manually from GitHub Actions UI with options:
+- **Package**: Specify which package to publish
+- **Skip version check**: Override version validation (use with extreme caution!)
+
+## Workflow Behavior Examples
+
+| Tag/Version | Will Publish? | Reason |
+|------------|---------------|---------|
+| `v1.0.0` | ✅ Yes | Stable semantic version |
+| `v2.5.10` | ✅ Yes | Stable semantic version |
+| `v1.0.0-beta.1` | ❌ No | Contains beta identifier |
+| `v1.0.0-alpha` | ❌ No | Contains alpha identifier |
+| `v1.0.0-rc.1` | ❌ No | Contains rc identifier |
+| `1.0.0` | ❌ No | Missing 'v' prefix |
+| `v1.0` | ❌ No | Not complete semantic version |
+
+## Migration from Current Workflow
+
+To replace the current `publish.yml` with the stable-only version:
+
+1. **Backup current workflow**:
+   ```bash
+   cp .github/workflows/publish.yml .github/workflows/publish.yml.backup
+   ```
+
+2. **Replace with stable-only workflow**:
+   ```bash
+   cp .github/workflows/publish-stable-only.yml .github/workflows/publish.yml
+   ```
+
+3. **Test with a dry run** (if needed):
+   - Create a test tag on a feature branch
+   - Monitor the workflow execution
+   - Verify it correctly identifies and validates versions
+
+## Troubleshooting
+
+### Workflow not triggering
+- Ensure tag follows pattern: `v[0-9]+.[0-9]+.[0-9]+`
+- Check repository settings for workflow permissions
+
+### Version validation fails
+- Verify package.json version is in X.Y.Z format
+- Remove any pre-release identifiers from version string
+
+### npm publish fails
+- Ensure `npm_token` secret is configured in repository settings
+- Verify package name is not already taken on npm registry
+
+## Benefits of This Approach
+
+1. **Prevents accidental beta publications** to the `latest` npm tag
+2. **Clear separation** between stable and pre-release workflows
+3. **Multiple validation layers** ensure only intended versions are published
+4. **Automatic GitHub release creation** for stable versions
+5. **Maintains npm tag integrity** (`latest` for stable, `beta` for pre-releases)


### PR DESCRIPTION
## Summary

This PR adds a new GitHub Actions workflow that ensures only stable versions are published to npm, preventing beta/alpha/rc versions from being accidentally published to the npm 'latest' tag.

## Changes

### New Files
- **`.github/workflows/publish-stable-only.yml`** - New workflow that only publishes stable versions
- **`STABLE_RELEASE_GUIDE.md`** - Documentation explaining the stable release process

## Key Features

### 1. Strict Version Validation
- Only triggers on stable version tags (v1.0.0, v2.5.10, etc.)
- Rejects any version containing beta, alpha, rc, pre, preview, dev, or canary
- Multiple validation layers ensure only stable versions are published

### 2. Tag Pattern Matching
- Matches: `v[0-9]+.[0-9]+.[0-9]+`
- Excludes: Any tag with pre-release identifiers

### 3. Enhanced Publishing Process
- Publishes to npm with the 'latest' tag (not 'beta')
- Automatically creates GitHub releases for stable versions
- Updates dependencies to latest stable versions only

## Benefits

✅ Prevents accidental beta publications to npm 'latest' tag
✅ Clear separation between stable and pre-release workflows  
✅ Multiple validation points prevent mistakes
✅ Maintains proper npm tag integrity
✅ Automated GitHub release creation for stable versions

## How to Use

1. Keep existing `publish.yml` for backward compatibility
2. Use `publish-stable-only.yml` for stable releases
3. Or replace `publish.yml` with the new workflow

## Testing

The workflow has been designed with comprehensive validation and will fail fast if:
- Tag doesn't match stable version pattern
- package.json contains pre-release version
- Any pre-release identifier is detected

This ensures only production-ready stablThis ensures only production-ready .